### PR TITLE
chore: migrate GitHub Pages deploy to official actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Publish github pages
+name: Deploy to GitHub Pages
 
 on:
   push:
@@ -7,22 +7,45 @@ on:
     branches: [main]
 
 jobs:
-  publish:
+  build-pages:
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Use Node.js
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "20"
           cache: "npm"
-      - run: npm ci
-      - run: npm run build
-      - name: Deploy Github pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-        if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          path: ./docs
+
+  deploy-pages:
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    needs: build-pages
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

- Replace `peaceiris/actions-gh-pages` with official `upload-pages-artifact` + `deploy-pages` actions
- Switch from token-based to OIDC-based deployment
- Reduce permissions from `contents: write` to `contents: read` (build) / `pages: write` + `id-token: write` (deploy)

**Changes:**
- Split single `publish` job into `build-pages` + `deploy-pages` jobs
- Add concurrency control for deployments
- Integrate `github-pages` environment

**Unchanged:**
- Build process (npm ci, npm run build)
- Node.js version (20)
- Build output directory (./docs)
- Action versions for checkout and setup-node (existing newer SHAs preserved)

## Test plan

- [ ] `build-pages` job passes on this PR
- [ ] `deploy-pages` job is skipped on this PR (expected)
- [ ] After merge: both `build-pages` and `deploy-pages` pass on main
- [ ] GitHub Pages URL loads correctly after merge
- [ ] `gh api "repos/.../pages" --jq '.build_type'` returns `workflow`

## Pre-merge requirements

- [ ] Pages source must be changed to "GitHub Actions" (Settings → Pages → Source)
- [ ] Branch protection: update required status check from `publish` to `build-pages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Pages deployment workflow by restructuring into separate build and deployment stages for enhanced reliability and control
  * Added concurrency controls to prevent simultaneous deployments
  * Refined security permissions for deployment operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->