### PR TITLE
chore: add zizmor GitHub Actions security audit workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          upload-sarif: true


### PR DESCRIPTION
## Summary

Add [zizmor](https://github.com/zizmorcore/zizmor) static analysis workflow for GitHub Actions security auditing. SARIF results are uploaded to GitHub Code Scanning.

**Changes:**
- Add `.github/workflows/zizmor.yml` with SHA-pinned actions, minimal permissions, and SARIF upload

**Unchanged:**
- Existing workflows (`ci_main.yml`, `npm_publish.yml`, `gh-pages.yml`)

## Test plan

- [ ] Verify zizmor workflow runs on this PR
- [ ] Confirm SARIF results appear in Code Scanning tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated security scanning workflow integrated into the CI/CD pipeline. The workflow automatically executes on code pushes and pull requests targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->