### PR TITLE
fix: resolve code scanning alerts for workflow hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,14 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 5 # Control overall update frequency for GitHub Actions
+      default-days: 7 # Control overall update frequency for GitHub Actions
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 5
+      default-days: 7
       semver-major-days: 30  # Breaking changes require careful review
       semver-minor-days: 7   # Feature additions need verification
-      semver-patch-days: 3   # Bug fixes and security patches applied quickly
+      semver-patch-days: 7   # Bug fixes and security patches applied quickly

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -19,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Use Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:


### PR DESCRIPTION
## Summary

Resolve all 7 open code scanning alerts (CodeQL + zizmor).

## Scope

**Changes:**
- `ci_main.yml`: Add explicit `permissions: contents: read` and `persist-credentials: false`
- `npm_publish.yml`, `gh-pages.yml`: Add `persist-credentials: false` to checkout
- `dependabot.yml`: Raise `default-days` from 5 to 7, `semver-patch-days` from 3 to 7

**Unchanged:**
- Workflow triggers, action versions, and build steps

## Test Plan

- [ ] CI passes on this PR
- [ ] Code scanning re-runs and alerts close automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration for dependency management timing
  * Enhanced GitHub Actions workflows with improved security configurations for build and deployment processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->