### PR TITLE
chore: migrate npm publish workflow to workflow_dispatch with approval gate

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -97,6 +97,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.validate.outputs.commit_sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,28 +1,129 @@
-name: Publish to NPM
+name: Publish to npm
+# Usage:
+#   CLI: gh workflow run npm_publish.yml --ref v1.0.0
+#   Web: Actions > "Publish to npm" > select tag from "Use workflow from" dropdown > Run
+
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
-  npm-publish:
+  validate:
     runs-on: ubuntu-22.04
     permissions:
-      id-token: write  # Required for OIDC authentication
-      contents: read   # Required for repository access
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REF: ${{ github.ref }}
+      TAG: ${{ github.ref_name }}
+      REPO: ${{ github.repository }}
+      DISPATCH_SHA: ${{ github.sha }}
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+      commit_sha: ${{ steps.resolve_tag.outputs.sha }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Verify dispatch ref is a tag
+        run: |
+          if [[ "$REF" != refs/tags/* ]]; then
+            echo "::error::Workflow must be dispatched from a tag ref, got: $REF"
+            exit 1
+          fi
+
+      - name: Validate tag format
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid tag format: $TAG (expected v*.*.* pattern)"
+            exit 1
+          fi
+
+      - name: Verify tag exists and resolve commit SHA
+        id: resolve_tag
+        run: |
+          TAG_REF=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" \
+            --jq '.object.sha + " " + .object.type') || {
+            echo "::error::Failed to look up tag $TAG"
+            exit 1
+          }
+          TAG_OBJ_SHA=$(echo "$TAG_REF" | cut -d' ' -f1)
+          TAG_OBJ_TYPE=$(echo "$TAG_REF" | cut -d' ' -f2)
+          if [ "$TAG_OBJ_TYPE" = "commit" ]; then
+            COMMIT_SHA="$TAG_OBJ_SHA"
+          else
+            COMMIT_SHA=$(gh api "repos/${REPO}/git/tags/${TAG_OBJ_SHA}" \
+              --jq '.object.sha') || {
+              echo "::error::Failed to resolve annotated tag $TAG"
+              exit 1
+            }
+          fi
+          if [ "$COMMIT_SHA" != "$DISPATCH_SHA" ]; then
+            echo "::error::Tag commit ($COMMIT_SHA) differs from dispatch commit ($DISPATCH_SHA). Tag may have been force-moved."
+            exit 1
+          fi
+          echo "Tag $TAG verified at commit $COMMIT_SHA"
+          echo "sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Verify GitHub Release is published
+        run: |
+          RELEASE=$(gh api "repos/${REPO}/releases/tags/${TAG}" \
+            --jq '[.draft, .name] | @tsv') || {
+            echo "::error::No GitHub Release found for tag $TAG"
+            exit 1
+          }
+          IS_DRAFT=$(echo "$RELEASE" | cut -f1)
+          RELEASE_NAME=$(echo "$RELEASE" | cut -f2)
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "::error::Release for $TAG is still a draft"
+            exit 1
+          fi
+          echo "Release verified: $RELEASE_NAME"
+
+      - name: Extract version from tag
+        id: extract
+        run: |
+          VERSION="$TAG"
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: validate
+    runs-on: ubuntu-22.04
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
-      - name: Use Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+          ref: ${{ needs.validate.outputs.commit_sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
-      - name: Upgrade npm to latest
-        run: npm install -g npm@latest
-      - run: npm ci
-      - name: build binary
+
+      - name: Verify package.json version matches tag
+        env:
+          TAG_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "Version match: $PKG_VERSION"
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g "npm@^11.10.0"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
         run: npm run buildTS
-      - name: Publish package on NPM 📦
-        run: npm publish --access public
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Migrate npm publish workflow from `release: [published]` auto-trigger to `workflow_dispatch` with GitHub Environment approval gate for safer npm publishing.

## Scope

**Changes:**
- Trigger: `release: [published]` → `workflow_dispatch` (dispatched from tag ref)
- Structure: single job → two jobs (validate + publish)
- Validate job: tag format, tag existence, release status, version match checks
- Publish job: GitHub Environment `npm-publish` with required reviewer approval
- OIDC trusted publishing with `--provenance` flag
- Node.js 20 → 22, npm upgrade for OIDC support
- Command injection prevention: all `${{ }}` expressions via `env:` context
- SHA pinning for all actions

**Unchanged:**
- Build command (`npm run buildTS`)
- npm access level (`--access public`)
- OIDC authentication mechanism (`id-token: write`)

## Test plan

- [ ] Verify workflow file syntax (two jobs: validate + publish)
- [ ] Verify SHA pinning on all action references
- [ ] Verify `id-token: write` permission on publish job
- [ ] Verify GitHub Environment `npm-publish` exists with reviewer configured
- [ ] Verify npm Trusted Publisher configured for this repo/workflow/environment
- [ ] After merge: test with `gh workflow run npm_publish.yml --ref <existing-tag>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to a manual release workflow with stricter tag and release validation to prevent accidental or mismatched publishes.
  * Tightened publishing permissions and improved provenance and verification steps for npm publishes.
  * Updated publishing runtime to Node 22 and added checks to ensure package version matches the release tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->