### PR TITLE
ci: add npm audit signatures job for supply chain security

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -10,6 +10,22 @@ on:
     branches: [main]
 
 jobs:
+  audit-signatures:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+          cache: "npm"
+      - run: npm ci
+      - run: npm audit signatures
+
   build:
     runs-on: ubuntu-22.04
     permissions:


### PR DESCRIPTION
## Summary

- Add dedicated `audit-signatures` job to CI that validates npm package registry signatures and Sigstore provenance certificates

**Changes:**
- New `audit-signatures` job in `ci_main.yml` running `npm audit signatures`

**Unchanged:**
- Existing `build` matrix job (Node 20/22/24)

## Design decisions

- Dedicated job instead of matrix step: signature verification is registry-level, not Node.js-version-dependent — single run is sufficient
- Runs in parallel with `build` matrix: no dependency between jobs, zero impact on CI completion time
- Node.js 24.x pinned: matches DevContainer, bundled npm has all signature verification fixes
- `permissions: contents: read` only (minimum privilege)

## Test plan

- [ ] CI passes on this PR
- [ ] `audit-signatures` job runs in parallel with `build` matrix
- [ ] Job logs show "verified registry signatures" output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new security validation step to the continuous integration workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->